### PR TITLE
feat: created reusable badge component

### DIFF
--- a/src/assets/projects.svg
+++ b/src/assets/projects.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M7 3a1 1 0 000 2h6a1 1 0 100-2H7zM4 7a1 1 0 011-1h10a1 1 0 110 2H5a1 1 0 01-1-1zM2 11a2 2 0 012-2h12a2 2 0 012 2v4a2 2 0 01-2 2H4a2 2 0 01-2-2v-4z"></path></svg>

--- a/src/components/Badge.vue
+++ b/src/components/Badge.vue
@@ -17,8 +17,8 @@ export default {
         'badgeName': String
     },
     setup() {
-        const getImageUrl = (name) => {
-            return new URL(`../assets/${name}`, import.meta.url).href
+        const getImageUrl = (path) => {
+            return new URL(`${path}`, import.meta.url).href
         }
         return {
             getImageUrl

--- a/src/components/Badge.vue
+++ b/src/components/Badge.vue
@@ -2,7 +2,7 @@
 
     <span
         class="bg-blue-100 inline-flex text-blue-800 text-xs font-semibold mr-2 px-2.5 py-0.5 gap-1 items-center justify-center rounded dark:bg-indigo-200 dark:text-indigo-900">
-        <img class="w-3 h-3" :src="getImageUrl(badgeImage)">
+        <img class="w-3 h-3" :src="getImageUrl(badgeImagePath)">
         <p>
             {{badgeName}}
         </p>
@@ -12,8 +12,7 @@
 <script>
 export default {
     props: {
-
-        'badgeImage': String,
+        'badgeImagePath': String,
         'badgeName': String
     },
     setup() {

--- a/src/components/Badge.vue
+++ b/src/components/Badge.vue
@@ -1,0 +1,28 @@
+<template>
+
+    <span
+        class="bg-blue-100 inline-flex text-blue-800 text-xs font-semibold mr-2 px-2.5 py-0.5 gap-1 items-center justify-center rounded dark:bg-indigo-200 dark:text-indigo-900">
+        <img class="w-3 h-3" :src="getImageUrl(badgeImage)">
+        <p>
+            {{badgeName}}
+        </p>
+    </span>
+</template>
+
+<script>
+export default {
+    props: {
+
+        'badgeImage': String,
+        'badgeName': String
+    },
+    setup() {
+        const getImageUrl = (name) => {
+            return new URL(`../assets/${name}`, import.meta.url).href
+        }
+        return {
+            getImageUrl
+        }
+    }
+}
+</script>


### PR DESCRIPTION
reusable badge component that takes in 2 props:
1. badgeImage (takes in name of asset, not path i.e projects.svg instead of ../assets/projects.svg) 
2. badgeName (name of badge)