### PR TITLE
changed list item hover background color

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -13,7 +13,7 @@
         </div>
         <ul class="space-y-2 p-[10px]  mt-[15px]" :class="{'px-0':showSideBar}">
             <li>
-                <div class="p-2 rounded-lg hover:bg-gray-700">
+                <div class="p-2 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700">
                     <a href='/'
                         class="flex items-center text-base font-normal text-gray-900 rounded-lg dark:text-white ">
                         <img class="w-6 h-6 text-gray-500 transition duration-75 dark:text-gray-400 "
@@ -23,7 +23,7 @@
                 </div>
             </li>
             <li>
-                <div class="p-2 rounded-lg hover:bg-gray-700">
+                <div class="p-2 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700">
                     <a href='/'
                         class="flex items-center text-base font-normal text-gray-900 rounded-lg dark:text-white ">
                         <img class="w-6 h-6 text-gray-500 transition duration-75 dark:text-gray-400 "
@@ -34,7 +34,7 @@
             </li>
             <hr class=" border-gray-300 dark:border-gray-700" />
             <li>
-                <div class="p-2 rounded-lg hover:bg-gray-700">
+                <div class="p-2 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700">
                     <a href='/'
                         class="flex items-center text-base font-normal text-gray-900 rounded-lg dark:text-white ">
                         <img class="w-6 h-6 text-gray-500 transition duration-75 dark:text-gray-400 "
@@ -52,7 +52,6 @@
 <script>
 import { ref } from 'vue'
 import Button from './Button.vue'
-import ListItem from './SidebarListItem.vue'
 import PageContentPlaceholder from './PageContentPlaceholder.vue'
 import SampleContent from './SampleContent.vue';
 
@@ -63,7 +62,6 @@ export default {
     },
     components: {
         "Button": Button,
-        "ListItem": ListItem,
         "PageContentPlaceholder": PageContentPlaceholder,
         SampleContent
     },


### PR DESCRIPTION
<!--
Thank you for contributing!
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

## Context

Closes #16 

## Implementation
simply changed the bg to` bg-gray-200` instead of `bg-gray-700` for hover selector for light mode.

![Screenshot 2022-10-09 at 5 02 40 PM](https://user-images.githubusercontent.com/68373112/194747921-c7294164-94bb-4a09-a32e-2bf768f4bae7.png)


