### PR TITLE
bugfix: cards skeleton ui not wrapping

### DIFF
--- a/src/components/ModuleCardSkeleton.vue
+++ b/src/components/ModuleCardSkeleton.vue
@@ -1,8 +1,8 @@
 <template>
   <div
-    class="bg-gray-50 dark:bg-gray-800 px-3 py-6 sm:px-6 md:p-8 lg:px-16 lg:py-9 rounded-2xl flex flex-col xl:flex-row justify-between max-w-screen-2xl lg:flex-row h-[16.2rem] animate-pulse"
+    class="bg-gray-50 dark:bg-gray-800 px-3 py-6 sm:px-6 md:p-8 lg:px-16 lg:py-9 rounded-2xl flex flex-col sm:flex-row justify-between max-w-screen-2xl w-full lg:flex-row h-[16.2rem] animate-pulse"
   >
-    <div class="grid content-center space-y-5 w-[55%]">
+    <div class="grid content-center space-y-5 w-[100%] sm:w-[55%]">
       <div class="grid grid-cols-6 gap-4">
         <div class="h-2 bg-gray-300 dark:bg-slate-700 rounded col-span-2"></div>
         <div class="h-2 bg-gray-300 dark:bg-slate-700 rounded col-span-3"></div>
@@ -26,7 +26,7 @@
         <div class="h-2 bg-gray-300 dark:bg-slate-700 rounded col-span-4"></div>
       </div>
     </div>
-    <div class="grid content-center space-y-5 w-[40%]">
+    <div class="hidden sm:grid content-center space-y-5 sm:w-[40%]">
       <div class="grid grid-cols-6 gap-4">
         <div class="h-2 bg-gray-300 dark:bg-slate-700 rounded col-span-2"></div>
         <div class="h-2 bg-gray-300 dark:bg-slate-700 rounded col-span-3"></div>


### PR DESCRIPTION
<!--
Thank you for contributing!
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

## Context

<!--
Please link to a Github issue (type `#` to autocomplete issue)
Example: `Closes #1` will close issue number 1.
-->

Card skeleton was not wrapping the Module card properly on small screens.

![image](https://user-images.githubusercontent.com/13061926/201529117-d552910d-8543-4554-b72e-3aebc3d94134.png)

Fix:
![image](https://user-images.githubusercontent.com/13061926/201529138-02e225f9-0ad9-4fe1-a2a1-066c286db383.png)
